### PR TITLE
Point `builder` dep at GitHub, not npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "babel-core": "6.3.26",
     "babel-loader": "6.2.1",
-    "builder": "2.4.0",
+    "builder": "https://github.com/FormidableLabs/builder",
     "clean-webpack-plugin": "0.1.5",
     "ecology": "1.0.4",
     "formidable-landers": "0.0.7",


### PR DESCRIPTION
... That way we get the current master when we rebuild, not the current npm release. Should work better with quick docs changes that don't warrant a bump on the `builder` side.

Fixes #4 

/cc @paulathevalley 
