### PR TITLE
Task: rebuild documentation, add intro to archetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ builder.formidable.com
 Marketing/documentation site for Builder
 
 # Publishing
-The site's documentation section is pulled in directly from the `builder` repo's README, which means it's only as current as your local `node_modules/builder`. To refresh the docs, run `npm run rebuild-readme`, which just nukes `builder` and reinstalls with the latest. (If you forget this step in dev, it's run automatically as part of `npm run build-static`, so you can't accidentally publish outdated docs.)
+The site's documentation section is pulled in directly from the `builder` repo's README, which means it's only as current as your local `node_modules/builder`. To refresh the docs, run `npm run reinstall-builder`, which just nukes `builder` and reinstalls with the latest. (If you forget this step in dev, it's run automatically as part of `npm run build-static`, so you can't accidentally publish outdated docs.)
 
 When it's time to publish:
 ```sh

--- a/components/app.jsx
+++ b/components/app.jsx
@@ -86,7 +86,7 @@ class App extends React.Component {
                 A builder “archetype” encapsulates shared configuration in a single source of truth. We’ve written archetypes for <a href="https://github.com/FormidableLabs/builder-react-component">React</a> and <a href="https://github.com/FormidableLabs/builder-victory-component">Victory</a> components so far, and we’re actively writing more. You can define an archetype for <strong>any type of application or component</strong>, including Backbone, Angular, and Node.
               </p>
               <p>
-                You can learn more about archetypes <a href="#archetypes">here</a>.
+                <a href="#archetypes">Learn more about archetypes</a>.
               </p>
             </div>
           </section>

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "webpack-dev-server --port 3000 --config webpack.config.dev.js",
-    "rebuild-readme": "rm -rf node_modules/builder && npm install",
+    "reinstall-builder": "rm -rf node_modules/builder && npm install",
     "webpack-static": "webpack --config webpack.config.static.js --progress --content-base /",
     "copy-assets": "cp -r static build/static",
     "copy-cname": "cp CNAME build/CNAME",
-    "build-static": "npm run rebuild-readme && npm run webpack-static && npm run copy-assets && npm run copy-cname",
+    "build-static": "npm run reinstall-builder && npm run webpack-static && npm run copy-assets && npm run copy-cname",
     "push-gh-pages": "git subtree push --prefix build origin gh-pages"
   },
   "repository": {


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/builder-docs/issues/6

This PR:
- Adds a quick intro to archetypes, with an internal link into the documentation.
- Adds a script to `npm install` the latest `builder` on every site build, to make sure what's published is always up to date. (In local dev, you can run `npm run rebuild-readme` to grab the latest from `builder`; if you forget this step, it's still run automatically as part of `npm run build-static`.)

/cc @coopy @paulathevalley 

![screen shot 2016-01-26 at 7 41 16 am](https://cloud.githubusercontent.com/assets/6352327/12585793/6ea80c70-c402-11e5-8fec-53f9bcf9218b.png)
