### PR TITLE
Task: Add Google Analytics to builder.formidable.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-flow-vars": "^0.1.3",
     "eslint-plugin-react": "^3.16.1",
     "http-server": "^0.8.5",
+    "react-ga": "^1.2.0",
     "webpack-dev-server": "1.14.0"
   },
   "dependencies": {

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1,15 +1,23 @@
 import React from "react";
 import Radium, { Style, StyleRoot } from "radium";
+import ga from "react-ga";
+const OutboundLink = ga.OutboundLink;
 
+// Child components
 import Diagram from "./diagram-flavors";
 import Docs from "./docs";
 import Hero from "./hero";
 import { Header, Footer } from "formidable-landers";
 
+// Variables
 import settings from "../builder-variables";
 import theme from "../builder-theme";
 
 class App extends React.Component {
+  componentWillMount() {
+    ga.initialize("UA-43290258-1");
+  }
+
   getHeaderLinkStyles() {
     return {
       color: settings.white,
@@ -83,7 +91,7 @@ class App extends React.Component {
                 Archetypes 101
               </h1>
               <p>
-                A builder “archetype” encapsulates shared configuration in a single source of truth. We’ve written archetypes for <a href="https://github.com/FormidableLabs/builder-react-component">React</a> and <a href="https://github.com/FormidableLabs/builder-victory-component">Victory</a> components so far, and we’re actively writing more. You can define an archetype for <strong>any type of application or component</strong>, including Backbone, Angular, and Node.
+                A builder “archetype” encapsulates shared configuration in a single source of truth. We’ve written archetypes for <OutboundLink to="https://github.com/FormidableLabs/builder-react-component" eventLabel="https://github.com/FormidableLabs/builder-react-component">React</OutboundLink> and <OutboundLink to="https://github.com/FormidableLabs/builder-victory-component" eventLabel="https://github.com/FormidableLabs/builder-victory-component">Victory</OutboundLink> components so far, and we’re actively writing more. You can define an archetype for <strong>any type of application or component</strong>, including Backbone, Angular, and Node.
               </p>
               <p>
                 <a href="#archetypes">Learn more about archetypes</a>.

--- a/src/components/diagram-flavors.jsx
+++ b/src/components/diagram-flavors.jsx
@@ -159,7 +159,9 @@ class Diagram extends React.Component {
             </div>
           </div>
         </Cell>
-        {this.props.archetype ? this.renderFlavorArchetype() : null}
+        <Cell width="1">
+          {this.props.archetype ? this.renderFlavorArchetype() : null}
+        </Cell>
       </Grid>
     );
   }

--- a/src/components/docs.jsx
+++ b/src/components/docs.jsx
@@ -1,6 +1,5 @@
 import Ecology from "ecology";
 import React from "react";
-import Radium from "radium";
 
 import BuilderREADME from "builder/README.md";
 
@@ -14,4 +13,4 @@ class Docs extends React.Component {
   }
 }
 
-export default Radium(Docs);
+export default Docs;

--- a/src/components/docs.jsx
+++ b/src/components/docs.jsx
@@ -1,5 +1,6 @@
 import Ecology from "ecology";
 import React from "react";
+import Radium from "radium";
 
 import BuilderREADME from "builder/README.md";
 
@@ -13,4 +14,4 @@ class Docs extends React.Component {
   }
 }
 
-export default Docs;
+export default Radium(Docs);


### PR DESCRIPTION
The `ga.initialize()` was set in the `router.jsx` of other apps, but builder does not have routes, so I put it in `<App>`. Does this sound correct? 

Also, we are aware of a warning in the console that should be resolved by wrapping a component in `Radium()` but I cannot find the culprit. /cc @tptee 

![screen shot 2016-02-11 at 1 25 53 pm](https://cloud.githubusercontent.com/assets/768965/12991523/6b2267ca-d0c4-11e5-981c-adcb2d9533d3.png)
