### PR TITLE
Fix React warnings about media queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "babel-preset-react": "6.3.13",
     "handlebars": "^4.0.5",
     "handlebars-loader": "^1.1.4",
-    "radium": "^0.16.2",
-    "radium-grid": "^1.0.4",
+    "radium": "^0.16.6",
+    "radium-grid": "^1.0.7",
     "react-dom": "0.14.5"
   }
 }

--- a/src/components/diagram-flavors.jsx
+++ b/src/components/diagram-flavors.jsx
@@ -92,13 +92,13 @@ class Diagram extends React.Component {
     return (
       <ul style={this.getRepoListStyles()}>
         <li>.babelrc</li>
-        <li>.eslintrc-base</li>
-        <li>.eslintrc-client</li>
+        <li>.eslintrc-base</li>
+        <li>.eslintrc-client</li>
         <li>.eslintrc-client-test</li>
-        <li>.eslintrc-server</li>
+        <li>.eslintrc-server</li>
         <li>webpack.config.coverage.js</li>
-        <li>webpack.config.dev.js</li>
-        <li>webpack.config.js</li>
+        <li>webpack.config.dev.js</li>
+        <li>webpack.config.js</li>
         <li>webpack.config.test.js</li>
       </ul>
     );
@@ -159,7 +159,9 @@ class Diagram extends React.Component {
             </div>
           </div>
         </Cell>
-        {this.props.archetype ? this.renderFlavorArchetype() : null}
+        <Cell width="1">
+          {this.props.archetype ? this.renderFlavorArchetype() : null}
+        </Cell>
       </Grid>
     );
   }


### PR DESCRIPTION
The flavor archetype div needed a `<Cell />` wrapped around it. I added the following explanation to the [radium-grid](https://github.com/FormidableLabs/radium-grid) README:

## Gotchas
`<Grid />` only accepts `<Cell />`s as children, since inserting arbitrary children can break the layout. Two options for custom children are:
- Wrap the children in a `<Cell />`.
- Move the children to a sibling of `<Grid>`.