### PR TITLE
Fix build static error

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint-plugin-flow-vars": "^0.1.3",
     "eslint-plugin-react": "^3.16.1",
     "http-server": "^0.8.5",
-    "react-ga": "^1.2.0",
     "webpack-dev-server": "1.14.0"
   },
   "dependencies": {
@@ -45,6 +44,7 @@
     "formidable-landers": "0.0.7",
     "raw-loader": "0.5.1",
     "react": "0.14.5",
+    "react-ga": "^1.2.0",
     "static-site-generator-webpack-plugin": "2.0.1",
     "webpack": "1.12.9",
     "webpack-stats-plugin": "0.1.1",

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -14,7 +14,7 @@ import settings from "../builder-variables";
 import theme from "../builder-theme";
 
 class App extends React.Component {
-  componentWillMount() {
+  componentDidMount() {
     ga.initialize("UA-43290258-1");
   }
 


### PR DESCRIPTION
The static build was returning this fun error: 
```
ERROR in ReferenceError: window is not defined
    at Object.reactGA.initialize (main:22724:9)
```

- Change initialize to live in `componentDidMount()` resolves the error
- Also move `react-ga` to dependencies

`npm run build-static` and `npm run server-static` are happy now!