### PR TITLE
Fix radium background warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "builder-docs-archetype": "0.0.4",
     "builder": "FormidableLabs/builder",
     "ecology": "1.5.0",
-    "formidable-landers": "^2.1.0",
+    "formidable-landers": "^3.0.0",
     "prismjs": "^1.4.1",
     "radium": "^0.17.1",
     "radium-grid": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "builder-docs-archetype": "0.0.4",
     "builder": "FormidableLabs/builder",
     "ecology": "1.0.4",
-    "formidable-landers": "^1.1.0",
+    "formidable-landers": "^2.1.0",
     "prismjs": "^1.4.1",
     "radium": "^0.16.6",
     "radium-grid": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   "dependencies": {
     "builder-docs-archetype": "0.0.4",
     "builder": "FormidableLabs/builder",
-    "ecology": "1.0.4",
+    "ecology": "1.5.0",
     "formidable-landers": "^2.1.0",
     "prismjs": "^1.4.1",
-    "radium": "^0.16.6",
+    "radium": "^0.17.1",
     "radium-grid": "^1.0.9",
-    "react": "0.14.5",
-    "react-dom": "0.14.5",
+    "react": "^15.2.0",
+    "react-dom": "^15.2.0",
     "react-ga": "^1.2.0"
   }
 }

--- a/src/builder-theme.js
+++ b/src/builder-theme.js
@@ -17,7 +17,7 @@ export default {
     fontSize: "17px"
   },
   body: {
-    backgroundColor: settings.jet,
+    background: settings.jet,
     fontFamily: settings.sansSerif,
     fontWeight: "300",
     lineHeight: 1.675,
@@ -159,12 +159,12 @@ export default {
     color: settings.jet,
     fontWeight: "500",
     textDecoration: "none",
-    backgroundColor: "transparent",
+    background: "transparent",
     borderBottom: `3px solid ${settings.gold}`,
     transition: "all 0.5s ease"
   },
   "a:hover, a:focus": {
-    backgroundColor: settings.gold,
+    background: settings.gold,
     borderBottom: `3px solid ${settings.gold}`,
     transition: "all 0.5s ease"
   },
@@ -178,7 +178,7 @@ export default {
    * Buttons!
    */
   ".Button": {
-    backgroundColor: "transparent",
+    background: "transparent",
     border: `3px solid ${settings.gray}`,
     boxShadow: "none",
     color: settings.jet,
@@ -196,14 +196,14 @@ export default {
     transition: "color 0.2s ease, border-color 0.7s ease"
   },
   ".Button--spotlight": {
-    backgroundColor: settings.jet,
+    background: settings.jet,
     borderColor: settings.jet,
     color: settings.gray,
     fontSize: "1.25rem",
     transition: "color 0.2s ease, background-color 0.7s ease, border-color 0.7s ease"
   },
   ".Button--spotlight:hover, .Button--spotlight:focus": {
-    backgroundColor: settings.red,
+    background: settings.red,
     borderColor: settings.red,
     color: "#ffffff",
     transition: "color 0.2s ease, background-color 0.7s ease, border-color 0.7s ease"
@@ -235,7 +235,7 @@ export default {
   },
   ".Copy .highlight pre": {
     marginTop: 0,
-    backgroundColor: settings.gold,
+    background: settings.gold,
     color: "#fff",
     fontFamily: settings.monospace,
     fontSize: "1em",
@@ -270,7 +270,7 @@ export default {
     marginBottom: "0.25em"
   },
   ".Copy code, .Ecology code, .Focus code": {
-    backgroundColor: "rgba(135, 135, 135, 0.1)",
+    background: "rgba(135, 135, 135, 0.1)",
     fontFamily: settings.monospace,
     fontSize: "0.8625em",
     borderRadius: "3px",
@@ -281,7 +281,7 @@ export default {
     fontSize: "1rem"
   },
   ".highlight code": {
-    backgroundColor: "transparent",
+    background: "transparent",
     padding: 0
   },
   /*
@@ -294,12 +294,12 @@ export default {
    * Ecology text wrangling
    */
   ".Overview pre": {
-    backgroundColor: "rgba(135, 135, 135, 0.1)",
+    background: "rgba(135, 135, 135, 0.1)",
     padding: "1em 0.5em",
     overflowX: "scroll" // bring back scrollbars for readme.md
   },
   ".Overview pre code": {
-    backgroundColor: "none"
+    background: "none"
   },
   /*
    * Interactive/Component Playground
@@ -326,7 +326,7 @@ export default {
   ".Interactive .playgroundCode": {
     flex: "0 0 100%",
     verticalAlign: "top",
-    backgroundColor: "#fff",
+    background: "#fff",
     fontFamily: settings.monospace,
     fontSize: "1rem",
     lineHeight: 1.2,
@@ -337,7 +337,7 @@ export default {
   ".Interactive .playgroundPreview": {
     flex: "0 0 100%",
     verticalAlign: "top",
-    backgroundColor: "#fff",
+    background: "#fff",
     position: "relative",
     border: "1px solid #ebe3db"
   },

--- a/src/builder-theme.js
+++ b/src/builder-theme.js
@@ -17,8 +17,7 @@ export default {
     fontSize: "17px"
   },
   body: {
-    backgroundColor: settings.white,
-    background: settings.jet,
+    backgroundColor: settings.jet,
     fontFamily: settings.sansSerif,
     fontWeight: "300",
     lineHeight: 1.675,
@@ -236,7 +235,7 @@ export default {
   },
   ".Copy .highlight pre": {
     marginTop: 0,
-    background: settings.gold,
+    backgroundColor: settings.gold,
     color: "#fff",
     fontFamily: settings.monospace,
     fontSize: "1em",
@@ -271,7 +270,7 @@ export default {
     marginBottom: "0.25em"
   },
   ".Copy code, .Ecology code, .Focus code": {
-    background: "rgba(135, 135, 135, 0.1)",
+    backgroundColor: "rgba(135, 135, 135, 0.1)",
     fontFamily: settings.monospace,
     fontSize: "0.8625em",
     borderRadius: "3px",
@@ -282,7 +281,7 @@ export default {
     fontSize: "1rem"
   },
   ".highlight code": {
-    background: "transparent",
+    backgroundColor: "transparent",
     padding: 0
   },
   /*
@@ -295,12 +294,12 @@ export default {
    * Ecology text wrangling
    */
   ".Overview pre": {
-    background: "rgba(135, 135, 135, 0.1)",
+    backgroundColor: "rgba(135, 135, 135, 0.1)",
     padding: "1em 0.5em",
     overflowX: "scroll" // bring back scrollbars for readme.md
   },
   ".Overview pre code": {
-    background: "none"
+    backgroundColor: "none"
   },
   /*
    * Interactive/Component Playground
@@ -327,7 +326,7 @@ export default {
   ".Interactive .playgroundCode": {
     flex: "0 0 100%",
     verticalAlign: "top",
-    background: "#fff",
+    backgroundColor: "#fff",
     fontFamily: settings.monospace,
     fontSize: "1rem",
     lineHeight: 1.2,
@@ -338,7 +337,7 @@ export default {
   ".Interactive .playgroundPreview": {
     flex: "0 0 100%",
     verticalAlign: "top",
-    background: "#fff",
+    backgroundColor: "#fff",
     position: "relative",
     border: "1px solid #ebe3db"
   },

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -84,7 +84,7 @@ class App extends React.Component {
     const footerStyles = this.getFooterSkewStyles();
     return (
       <StyleRoot>
-        <Header backgroundColor={settings.darkerJet} linkStyles={this.getLightLinkStyles()} />
+        <Header background={settings.darkerJet} linkStyles={this.getLightLinkStyles()} />
         <Hero />
         <div style={this.getMainStyles()}>
           <section style={{position: "relative"}}>
@@ -135,7 +135,7 @@ class App extends React.Component {
           </section>
         </div>
         <Footer
-          backgroundColor={settings.white}
+          background={settings.white}
           logoColor="white"
           styleOverrides={{
             margin: "0",

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -24,11 +24,11 @@ class App extends React.Component {
       borderColor: settings.lighterJet,
       ":hover": {
         color: settings.darkGold,
-        backgroundColor: settings.jet
+        background: settings.jet
       },
       ":focus": {
         color: settings.darkGold,
-        backgroundColor: settings.jet
+        background: settings.jet
       }
     };
   }
@@ -67,7 +67,7 @@ class App extends React.Component {
         right: "0",
         zIndex: "-1",
         height: "75%",
-        backgroundColor: settings.jet
+        background: settings.jet
       },
       right: {
         background: `linear-gradient(0deg, ${settings.darkerJet}, ${settings.gray}, ${settings.white})`,
@@ -135,7 +135,7 @@ class App extends React.Component {
           </section>
         </div>
         <Footer
-          backgroundColor={settings.white}
+          background={settings.white}
           logoColor="white"
           styleOverrides={{
             margin: "0",

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -135,7 +135,7 @@ class App extends React.Component {
           </section>
         </div>
         <Footer
-          background={settings.white}
+          backgroundColor={settings.white}
           logoColor="white"
           styleOverrides={{
             margin: "0",

--- a/src/components/diagram-flavors.jsx
+++ b/src/components/diagram-flavors.jsx
@@ -74,8 +74,7 @@ class Diagram extends React.Component {
   getFlavorArchetypeStyles() {
     return {
       zIndex: "1",
-
-      backgroundColor: settings.gray,
+      background: settings.gray,
       color: settings.darkerJet,
       fontFamily: settings.monospace,
       fontSize: ".777777rem",

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -23,7 +23,7 @@ class Hero extends React.Component {
       height: "120%",
       transformOrigin: "top left",
       transform: "skew(0deg, 15deg)",
-      backgroundColor: settings.jet
+      background: settings.jet
     };
   }
 
@@ -38,7 +38,7 @@ class Hero extends React.Component {
 
   getInstallerHeadingStyles() {
     return {
-      backgroundColor: settings.gold,
+      background: settings.gold,
       border: `1px solid ${settings.darkGold}`,
       color: settings.jet,
       display: "inline-block",


### PR DESCRIPTION
Partially fixes #21.

There is one additional `backgroundColor` property in the footer that is written on here - https://github.com/FormidableLabs/formidable-landers/blob/master/src/components/footer.jsx#L13

The plan is to deprecate the `backgroundColor` prop on the Footer component in place of a more flexible `background` property that will allow use of `linear-gradient`

cc @coopy 