### PR TITLE
Move ReactGA back to the App component

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -8,12 +8,21 @@ import Diagram from "./diagram-flavors";
 import Docs from "./docs";
 import Hero from "./hero";
 import { Header, Footer } from "formidable-landers";
+import basename from "../basename";
 
 // Variables
 import settings from "../builder-variables";
 import theme from "../builder-theme";
 
 class App extends React.Component {
+  componentDidMount() {
+    // Add Google Analytics tracking here since react-router
+    // isn’t being used in entry.js
+    ReactGA.initialize("UA-43290258-1");
+    ReactGA.set({page: basename});
+    ReactGA.pageview(basename);
+  }
+
   getLightLinkStyles() {
     return {
       color: settings.white,

--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -1,21 +1,15 @@
 import React from "react";
 import { render } from "react-dom";
 import { renderToString } from "react-dom/server";
-import ReactGA from "react-ga";
 
 import App from "./app";
 import Index from "../../templates/index.hbs";
-import basename from "../basename";
 
 // Client render (optional):
 // `static-site-generator-webpack-plugin` supports shimming browser globals
 // so instead of checking whether the document is undefined (always false),
 // Check whether it’s being shimmed
 if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //eslint-disable-line no-undef
-  // Add Google Analytics tracking
-  ReactGA.initialize("UA-43290258-1");
-  ReactGA.set({page: basename});
-  ReactGA.pageview(basename);
   render(
     <App />,
     document.getElementById("content")


### PR DESCRIPTION
Re: https://github.com/FormidableLabs/formidable-landers/issues/138

Ok, `ReactGA` can't be in `entry.js`, because there's no `<Router>` listening. Moved it back to `<App/>`!

/cc @ebrillhart  